### PR TITLE
Fix for #25: CellDiff2Vec doesn't terminate

### DIFF
--- a/test/classes/test_cell_diff2vec.py
+++ b/test/classes/test_cell_diff2vec.py
@@ -9,18 +9,6 @@ from topoembedx.classes.cell_diff2vec import CellDiff2Vec
 class TestDiff2Vec:
     """Test Diff2Vec class."""
 
-    def test_fit(self):
-        """Test the fit method."""
-        # Create a small graph
-        cc_large = tnx.classes.CellComplex([[i, i + 1, i + 2, i + 3] for i in range(0, 100, 3)], ranks=2)
-
-        model = CellDiff2Vec(dimensions=2)
-        try:
-            model.fit(cc_large)
-            print("Model 3 fit successfully")
-        except Exception as e:
-            print("Error during fit for Model 3:", str(e))
-
     def test_init(self):
         """Test get_embedding."""
         # Create a small graph
@@ -29,3 +17,14 @@ class TestDiff2Vec:
 
         # Create a CellDiff2Vec object
         _ = CellDiff2Vec(dimensions=2)
+
+    def test_fit(self):
+        """Test the fit method."""
+        # Create a larger graph
+        cx_large = tnx.classes.CellComplex([[i, i + 1, i + 2, i + 3] for i in range(0, 100, 3)], ranks=2)
+
+        # Create a CellDiff2Vec object
+        model = CellDiff2Vec(dimensions=2)
+
+        # Fit the CellDiff2Vec object to the graph and get embedding for nodes
+        model.fit(cx_large)

--- a/test/classes/test_cell_diff2vec.py
+++ b/test/classes/test_cell_diff2vec.py
@@ -9,6 +9,18 @@ from topoembedx.classes.cell_diff2vec import CellDiff2Vec
 class TestDiff2Vec:
     """Test Diff2Vec class."""
 
+    def test_fit(self):
+        """Test the fit method."""
+        # Create a small graph
+        cc_large = tnx.classes.CellComplex([[i, i + 1, i + 2, i + 3] for i in range(0, 100, 3)], ranks=2)
+
+        model = CellDiff2Vec(dimensions=2)
+        try:
+            model.fit(cc_large)
+            print("Model 3 fit successfully")
+        except Exception as e:
+            print("Error during fit for Model 3:", str(e))
+
     def test_init(self):
         """Test get_embedding."""
         # Create a small graph

--- a/test/classes/test_cell_diff2vec.py
+++ b/test/classes/test_cell_diff2vec.py
@@ -21,7 +21,9 @@ class TestDiff2Vec:
     def test_fit(self):
         """Test the fit method."""
         # Create a larger graph
-        cx_large = tnx.classes.CellComplex([[i, i + 1, i + 2, i + 3] for i in range(0, 100, 3)], ranks=2)
+        cx_large = tnx.classes.CellComplex(
+            [[i, i + 1, i + 2, i + 3] for i in range(0, 100, 3)], ranks=2
+        )
 
         # Create a CellDiff2Vec object
         model = CellDiff2Vec(dimensions=2)

--- a/topoembedx/classes/cell_diff2vec.py
+++ b/topoembedx/classes/cell_diff2vec.py
@@ -105,7 +105,8 @@ class CellDiff2Vec(Diff2Vec):
         g = nx.from_numpy_matrix(self.A)
         if self.diffusion_cover > g.number_of_nodes():
             raise ValueError(
-                "The diffusion_cover is too large for the size of the graph.")
+                "The diffusion_cover is too large for the size of the graph."
+            )
         super(CellDiff2Vec, self).fit(g)
 
     def get_embedding(self, get_dict=False):

--- a/topoembedx/classes/cell_diff2vec.py
+++ b/topoembedx/classes/cell_diff2vec.py
@@ -103,7 +103,9 @@ class CellDiff2Vec(Diff2Vec):
         )
 
         g = nx.from_numpy_matrix(self.A)
-
+        if self.diffusion_cover > g.number_of_nodes():
+            raise ValueError(
+                "The diffusion_cover is too large for the size of the graph.")
         super(CellDiff2Vec, self).fit(g)
 
     def get_embedding(self, get_dict=False):


### PR DESCRIPTION
The issue appears to be from complexes that are too small. The `_run_diffusion_process` method runs a while loop, comparing the number of nodes to `diffusion_cover` (which defaults to 80). For graphs with fewer than 80 nodes, this loop never terminates:

```python
def _run_diffusion_process(self, node):
    """
    Generating a diffusion tree from a given source node and linearizing it
    with a directed Eulerian tour.

    Args:
        node (int): The source node of the diffusion.

    Returns:
        list of str: The list of nodes in the walk.
    """
    infected = [node]
    sub_graph = nx.DiGraph()
    sub_graph.add_node(node)
    infected_counter = 1
    while infected_counter < self.diffusion_cover:
        end_point = random.sample(infected, 1)[0]
        nebs = [node for node in self.graph.neighbors(end_point)]
        sample = random.choice(nebs)
        if sample not in infected:
            infected_counter += 1
            infected.append(sample)
            sub_graph.add_edges_from([(end_point, sample), (sample, end_point)])
            if infected_counter == self.diffusion_cover:
                break
```

                    
To solve this I added an exception to `CellDiff2Vec` inside the `fit` method:
```python
if self.diffusion_cover > g.number_of_nodes():
        raise ValueError(
            "The diffusion_cover is too large for the size of the graph.")
```
            
I didn't find any more issues with graphs meeting this requirement. 

edit: Thank you Florian for spotting the issue with PathComplex! I reverted this change with rebase now.